### PR TITLE
Validate admins before signing in and fix alerts

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,18 +13,23 @@ class SessionsController < ApplicationController
     # Manages the callback from Google
     # Get access tokens from the google server
     access_token = request.env["omniauth.auth"]
-    # TODO: don't register if the name in the token is not in the database.
-    # Tell them to register.
-    admin = Admin.from_omniauth(access_token)
-    log_in admin
-    # Access_token is used to authenticate request made from the rails application to the google server
-    admin.google_token = access_token.credentials.token
-    # Refresh_token to request new access_token
-    # Note: Refresh_token is only sent once during the first request
-    refresh_token = access_token.credentials.refresh_token
-    admin.google_refresh_token = refresh_token if refresh_token.present?
-    admin.save
-    session[:logged_in] = true
-    redirect_to root_path
+
+    if Admin.validate_auth(access_token)
+      # TODO: don't register if the name in the token is not in the database.
+      # Tell them to register.
+      admin = Admin.from_omniauth(access_token)
+      log_in admin
+      # Access_token is used to authenticate request made from the rails application to the google server
+      admin.google_token = access_token.credentials.token
+      # Refresh_token to request new access_token
+      # Note: Refresh_token is only sent once during the first request
+      refresh_token = access_token.credentials.refresh_token
+      admin.google_refresh_token = refresh_token if refresh_token.present?
+      admin.save
+      session[:logged_in] = true
+      redirect_to root_path
+    else
+      redirect_to root_path, alert: "Please email Michael Ball at ball@berkely.edu to sign up as an administrator."
+    end
   end
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -13,4 +13,20 @@ class Admin < ActiveRecord::Base
       administrator.email = auth.info.email
     end
   end
+
+  def self.validate_auth(auth)
+    return self.validate_by_email(auth.info.email)
+  end
+
+
+  private
+
+    def self.validate_by_email(email)
+      # Check if the email is in a list of all BJC Teacher Tracker administrators and
+      # current developers of the app.
+      admin_emails = %w(ball@berkeley.edu')
+      developer_2019_emails = %w(wangye@berkeley.edu janani_vijaykumar@berkeley.edu
+                    daltons@berkeley.edu murthy@berkeley.edu zachchao@berkeley.edu)
+      return admin_emails.include?(email) || developer_2019_emails.include?(email)
+    end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -9,6 +9,7 @@ class School < ActiveRecord::Base
   end
 
   private
+
     def grab_lat_lng
       # Getting the long and lat of the city they put
       google_key = "AIzaSyC7jyOFHSorVb256ZEwvvyprp2KPjxKTPw"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,11 +35,8 @@
 </nav>
 
 <div class="container">
-  <% if notice%>
-    <% notice%>
-  <% end %>
-  <% if alert%>
-    <% alert%>
+  <% flash.each do |name, msg| %>
+    <%= content_tag :div, msg, class: "alert" %>
   <% end %>
   <%= yield %>
 </div>


### PR DESCRIPTION
Now only Michael and us (CS169 Team 3) are allowed to sign in as administrators with our Berkeley emails.

I also fixed alerts along the way.