### PR TITLE
Fixed submission alerts and prevents duplicate emails

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -3,18 +3,22 @@ require 'net/http'
 class TeachersController < ApplicationController
     def create
         # Receive nested hash from field_for in the view
-        @school = School.new school_params
-        if !@school.save
-            redirect_to root_path, alert: "Failed to submit information :("
+        if Teacher.exists?(email: teacher_params[:email])
+            redirect_to root_path, alert: "User with this email already exists"
         else
-            @teacher = @school.teachers.build teacher_params
-            @teacher.validated = false
-            if @teacher.save
-                flash[:saved_teacher] = true
-                TeacherMailer.form_submission(@teacher).deliver_now
-                redirect_to root_path
+            @school = School.new school_params
+            if !@school.save
+                redirect_to root_path, alert: "Error submitting school information"
             else
-                redirect_to root_path, alert: "Failed to submit information :("
+                @teacher = @school.teachers.build teacher_params
+                @teacher.validated = false
+                if @teacher.save
+                    flash[:saved_teacher] = true
+                    TeacherMailer.form_submission(@teacher).deliver_now
+                    redirect_to root_path
+                else
+                    redirect_to root_path, alert: "Error submitting teacher information"
+                end
             end
         end
     end

--- a/app/views/main/teacher_form.html.erb
+++ b/app/views/main/teacher_form.html.erb
@@ -1,10 +1,13 @@
 <div id='sign-up-form-container'>
   <h1 id="form-page-title">Sign up for BJC!</h1>
 
+  <div class="alert alert-warning">
+    <% if flash[:alert] %>
+      <%= flash[:alert] %>
+    <% end %>
+  </div>
   <% if flash[:saved_teacher] %>
     Thanks for signing up!
-  <% elsif flash[:failed] %>
-    Error saving
   <% else %>
     <%= form_for @teacher do |f| %>
       <div class='form-input-group'>


### PR DESCRIPTION
Varun and I made it so that if an email is already present in the database, whether the teacher is validated or not, another teacher cannot submit using the same email. We also fixed the alert messages so that when teachers get errors submitting the error is personalized a bit to what the error was from and the error is shown on the forms page with the form beneath it so they can correct their error.